### PR TITLE
Add bilingual website template

### DIFF
--- a/css/styles.css
+++ b/css/styles.css
@@ -1,0 +1,50 @@
+/*
+ * Custom styles for CodeFusion AI website
+ * Based on Creative template by StartBootstrap (MIT License)
+ */
+
+body {
+  font-family: 'Helvetica Neue', Arial, sans-serif;
+}
+
+#mainNav {
+  background-color: rgba(0, 0, 0, 0.7);
+}
+
+#mainNav .navbar-brand {
+  font-weight: 700;
+}
+
+header.masthead {
+  padding-top: 10rem;
+  padding-bottom: calc(10rem - 4.5rem);
+  background-image: url('https://images.unsplash.com/photo-1537432376769-00a5e63d5727?auto=format&fit=crop&w=1600&q=80');
+  background-position: center;
+  background-size: cover;
+}
+
+header.masthead h1 {
+  font-size: 2.25rem;
+}
+
+@media (min-width: 992px) {
+  header.masthead h1 {
+    font-size: 3.5rem;
+  }
+}
+
+section {
+  padding: 4rem 0;
+}
+
+footer {
+  padding: 2rem 0;
+  background-color: #212529;
+  color: #fff;
+}
+
+.navbar-shrink {
+  padding-top: 0.5rem !important;
+  padding-bottom: 0.5rem !important;
+}
+

--- a/index-es.html
+++ b/index-es.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="CodeFusion AI ofrece desarrollo backend, soluciones de inteligencia artificial, aprendizaje automático y automatización con experiencia en transporte, turismo, deporte, finanzas y medicina." />
+  <meta name="keywords" content="desarrollo backend, inteligencia artificial, machine learning, automatización, software" />
+  <meta name="author" content="CodeFusion AI" />
+  <title>CodeFusion AI - Desarrollo Backend y Soluciones de IA</title>
+  <link rel="canonical" href="index-es.html" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" />
+  <link href="css/styles.css" rel="stylesheet" />
+</head>
+<body id="page-top">
+  <!-- Navigation-->
+  <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
+    <div class="container">
+      <a class="navbar-brand" href="#page-top">CodeFusion AI</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+      <div class="collapse navbar-collapse" id="navbarResponsive">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="#services">Servicios</a></li>
+          <li class="nav-item"><a class="nav-link" href="#industries">Industrias</a></li>
+          <li class="nav-item"><a class="nav-link" href="#contact">Contacto</a></li>
+          <li class="nav-item"><a class="nav-link" href="index.html">EN</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+  <!-- Masthead-->
+  <header class="masthead text-white text-center">
+    <div class="container d-flex align-items-center flex-column">
+      <h1 class="masthead-heading mb-0">Soluciones Robustas de Backend e IA</h1>
+      <p class="masthead-subheading font-weight-light mb-0">Transformando negocios con automatización inteligente</p>
+    </div>
+  </header>
+  <!-- Services Section-->
+  <section id="services">
+    <div class="container">
+      <h2 class="text-center mt-0">Nuestra Experiencia</h2>
+      <div class="row justify-content-center">
+        <div class="col-lg-4 col-md-6 text-center">
+          <div class="mt-5">
+            <div class="mb-2"><i class="bi-gear fs-1 text-primary"></i></div>
+            <h3 class="h4 mb-2">Desarrollo Backend</h3>
+            <p class="text-muted mb-0">APIs de alto rendimiento y arquitecturas escalables.</p>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 text-center">
+          <div class="mt-5">
+            <div class="mb-2"><i class="bi-cpu fs-1 text-primary"></i></div>
+            <h3 class="h4 mb-2">IA y Machine Learning</h3>
+            <p class="text-muted mb-0">Analítica predictiva y soluciones inteligentes para tus datos.</p>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 text-center">
+          <div class="mt-5">
+            <div class="mb-2"><i class="bi-lightning fs-1 text-primary"></i></div>
+            <h3 class="h4 mb-2">Automatización</h3>
+            <p class="text-muted mb-0">Optimización de procesos para aumentar la eficiencia.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Industries Section-->
+  <section id="industries" class="bg-light">
+    <div class="container">
+      <h2 class="text-center">Experiencia en Industrias</h2>
+      <div class="row justify-content-center">
+        <div class="col-lg-8">
+          <p>Nuestros ingenieros han completado proyectos exitosos en una amplia gama de dominios:</p>
+          <ul>
+            <li>Transporte</li>
+            <li>Turismo</li>
+            <li>Deporte</li>
+            <li>Finanzas</li>
+            <li>Medicina</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Contact Section-->
+  <section id="contact">
+    <div class="container">
+      <h2 class="text-center mt-0">Contáctanos</h2>
+      <div class="row justify-content-center">
+        <div class="col-lg-8">
+          <form action="https://example.com/contact" method="post">
+            <div class="mb-3">
+              <label for="name" class="form-label">Nombre</label>
+              <input type="text" class="form-control" id="name" name="name" required />
+            </div>
+            <div class="mb-3">
+              <label for="email" class="form-label">Correo electrónico</label>
+              <input type="email" class="form-control" id="email" name="email" required />
+            </div>
+            <div class="mb-3">
+              <label for="message" class="form-label">Mensaje</label>
+              <textarea class="form-control" id="message" name="message" rows="5" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Enviar</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Footer-->
+  <footer class="text-center">
+    <div class="container"><small>&copy; 2024 CodeFusion AI &middot; <a href="index.html" class="text-white">English</a></small></div>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/scripts.js"></script>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,117 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="description" content="CodeFusion AI delivers backend development, AI, machine learning and automation solutions with experience in transportation, tourism, sports, finance and medicine." />
+  <meta name="keywords" content="backend development, AI, machine learning, automation, software" />
+  <meta name="author" content="CodeFusion AI" />
+  <title>CodeFusion AI - Backend & AI Solutions</title>
+  <link rel="canonical" href="index.html" />
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/css/bootstrap.min.css" rel="stylesheet" />
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.10.5/font/bootstrap-icons.css" />
+  <link href="css/styles.css" rel="stylesheet" />
+</head>
+<body id="page-top">
+  <!-- Navigation-->
+  <nav class="navbar navbar-expand-lg navbar-dark fixed-top" id="mainNav">
+    <div class="container">
+      <a class="navbar-brand" href="#page-top">CodeFusion AI</a>
+      <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation"><span class="navbar-toggler-icon"></span></button>
+      <div class="collapse navbar-collapse" id="navbarResponsive">
+        <ul class="navbar-nav ms-auto">
+          <li class="nav-item"><a class="nav-link" href="#services">Services</a></li>
+          <li class="nav-item"><a class="nav-link" href="#industries">Industries</a></li>
+          <li class="nav-item"><a class="nav-link" href="#contact">Contact</a></li>
+          <li class="nav-item"><a class="nav-link" href="index-es.html">ES</a></li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+  <!-- Masthead-->
+  <header class="masthead text-white text-center">
+    <div class="container d-flex align-items-center flex-column">
+      <h1 class="masthead-heading mb-0">Robust Backend & AI Solutions</h1>
+      <p class="masthead-subheading font-weight-light mb-0">Transforming businesses with intelligent automation</p>
+    </div>
+  </header>
+  <!-- Services Section-->
+  <section id="services">
+    <div class="container">
+      <h2 class="text-center mt-0">Our Expertise</h2>
+      <div class="row justify-content-center">
+        <div class="col-lg-4 col-md-6 text-center">
+          <div class="mt-5">
+            <div class="mb-2"><i class="bi-gear fs-1 text-primary"></i></div>
+            <h3 class="h4 mb-2">Backend Development</h3>
+            <p class="text-muted mb-0">High-performance APIs and scalable architectures.</p>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 text-center">
+          <div class="mt-5">
+            <div class="mb-2"><i class="bi-cpu fs-1 text-primary"></i></div>
+            <h3 class="h4 mb-2">AI & Machine Learning</h3>
+            <p class="text-muted mb-0">Predictive analytics and smart solutions for your data.</p>
+          </div>
+        </div>
+        <div class="col-lg-4 col-md-6 text-center">
+          <div class="mt-5">
+            <div class="mb-2"><i class="bi-lightning fs-1 text-primary"></i></div>
+            <h3 class="h4 mb-2">Automation</h3>
+            <p class="text-muted mb-0">Streamlining workflows to boost efficiency.</p>
+          </div>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Industries Section-->
+  <section id="industries" class="bg-light">
+    <div class="container">
+      <h2 class="text-center">Industry Experience</h2>
+      <div class="row justify-content-center">
+        <div class="col-lg-8">
+          <p>Our seasoned engineers have delivered successful projects across a wide range of domains:</p>
+          <ul>
+            <li>Transportation</li>
+            <li>Tourism</li>
+            <li>Sports</li>
+            <li>Finance</li>
+            <li>Medicine</li>
+          </ul>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Contact Section-->
+  <section id="contact">
+    <div class="container">
+      <h2 class="text-center mt-0">Contact Us</h2>
+      <div class="row justify-content-center">
+        <div class="col-lg-8">
+          <form action="https://example.com/contact" method="post">
+            <div class="mb-3">
+              <label for="name" class="form-label">Name</label>
+              <input type="text" class="form-control" id="name" name="name" required />
+            </div>
+            <div class="mb-3">
+              <label for="email" class="form-label">Email</label>
+              <input type="email" class="form-control" id="email" name="email" required />
+            </div>
+            <div class="mb-3">
+              <label for="message" class="form-label">Message</label>
+              <textarea class="form-control" id="message" name="message" rows="5" required></textarea>
+            </div>
+            <button type="submit" class="btn btn-primary">Send</button>
+          </form>
+        </div>
+      </div>
+    </div>
+  </section>
+  <!-- Footer-->
+  <footer class="text-center">
+    <div class="container"><small>&copy; 2024 CodeFusion AI &middot; <a href="index-es.html" class="text-white">Español</a></small></div>
+  </footer>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js"></script>
+  <script src="js/scripts.js"></script>
+</body>
+</html>

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -1,0 +1,20 @@
+// Custom scripts for CodeFusion AI website
+// Based on StartBootstrap Creative template (MIT License)
+
+window.addEventListener('DOMContentLoaded', event => {
+  const navbarShrink = function () {
+    const navbarCollapsible = document.body.querySelector('#mainNav');
+    if (!navbarCollapsible) {
+      return;
+    }
+    if (window.scrollY === 0) {
+      navbarCollapsible.classList.remove('navbar-shrink');
+    } else {
+      navbarCollapsible.classList.add('navbar-shrink');
+    }
+  };
+
+  navbarShrink();
+  document.addEventListener('scroll', navbarShrink);
+});
+


### PR DESCRIPTION
## Summary
- build English landing page showcasing backend, AI/ML and automation services with industry experience and contact form
- add Spanish translation and language toggle
- include custom styling and navbar behavior scripts

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_6895d0405710832a963fbf3837f53320